### PR TITLE
ci: Chrome Web Store 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Chrome Web Store
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build & Zip
+        run: npx wxt zip
+
+      - name: Upload & Publish to Chrome Web Store
+        run: npx chrome-webstore-upload-cli upload --source .output/*.zip --auto-publish
+        env:
+          EXTENSION_ID: ppbkhmnlabglcbkhdfihaalomphchpni
+          CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}


### PR DESCRIPTION
## Summary
- v* 태그 push 시 자동으로 빌드 → ZIP → Chrome Web Store 업로드/배포
- GitHub Secrets에 `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` 등록 필요

## Test plan
- [ ] GitHub Secrets 등록 후 `git tag v0.2.0 && git push origin v0.2.0`으로 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)